### PR TITLE
migrate set-output command to environment files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,9 +61,9 @@ fi
 echo "Latest ${VERSION_NAME}=${LATEST_VERSION}"
 
 # Set outputs.
-set_output current "${CURRENT_VERSION}"
-set_output latest "${LATEST_VERSION}"
-set_output repo "${REPO}"
+set_output "current" "${CURRENT_VERSION}"
+set_output "latest" "${LATEST_VERSION}"
+set_output "repo" "${REPO}"
 
 if [ "${CURRENT_VERSION}" = "${LATEST_VERSION}" ]; then
   echo "${VERSION_NAME} is latest. Nothing to do."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ set_output() {
   name=$1
   value=$2
   if [ -n "${GITHUB_OUTPUT}" ]; then
-    echo "$name=$value" >> "{$GITHUB_OUTPUT}"
+    echo "$name=$value" >> "${GITHUB_OUTPUT}"
   else
     echo "::set-output name=$name::$value"
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,16 @@ list_versions() {
   fi
 }
 
+set_output() {
+  name=$1
+  value=$2
+  if [ -n "${GITHUB_OUTPUT}" ]; then
+    echo "$name=$value" >> "{$GITHUB_OUTPUT}"
+  else
+    echo "::set-output name=$name::$value"
+  fi
+}
+
 LATEST_VERSION="$(\
   list_versions | \
   grep -oP '\d+(\.\d+)+(-[^'\''\"\s]*)?$'| \
@@ -51,9 +61,9 @@ fi
 echo "Latest ${VERSION_NAME}=${LATEST_VERSION}"
 
 # Set outputs.
-echo "::set-output name=current::${CURRENT_VERSION}"
-echo "::set-output name=latest::${LATEST_VERSION}"
-echo "::set-output name=repo::${REPO}"
+set_output current "${CURRENT_VERSION}"
+set_output latest "${LATEST_VERSION}"
+set_output repo "${REPO}"
 
 if [ "${CURRENT_VERSION}" = "${LATEST_VERSION}" ]; then
   echo "${VERSION_NAME} is latest. Nothing to do."


### PR DESCRIPTION
set-output commands are now deprecated.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

GitHub recommends environment files instead.
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files